### PR TITLE
コードのクリーンアップ

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -12,95 +12,48 @@ type CompilerResult = Result<(), Box<Error>>;
 
 impl Compiler {
     pub fn new() -> Self {
-        return Compiler {
-                   code: vec![],
-                   letrec_id_list: vec![],
-               };
+        Compiler {
+            code: vec![],
+            letrec_id_list: vec![],
+        }
     }
 
     fn error(&self, ast: &AST, msg: &str) -> CompilerResult {
-        return Err(From::from(format!("{}:{}:compile error: {}", ast.info[0], ast.info[1], msg)));
+        Err(From::from(format!("{}:{}:compile error: {}", ast.info[0], ast.info[1], msg)))
     }
 
     pub fn compile(&mut self, ast: &AST) -> Result<Code, Box<Error>> {
         try!(self.compile_(ast));
-        return Ok(self.code.clone());
+        Ok(self.code.clone())
     }
 
     pub fn compile_(&mut self, ast: &AST) -> CompilerResult {
         match ast.sexpr {
-            SExpr::Int(n) => {
-                return self.compile_int(ast, n);
-            }
-
-            SExpr::Atom(ref id) => {
-                return self.compile_atom(ast, id);
-            }
-
+            SExpr::Int(n) => self.compile_int(ast, n),
+            SExpr::Atom(ref id) => self.compile_atom(ast, id),
             SExpr::List(ref ls) => {
                 if ls.len() == 0 {
-                    return self.compile_nil(ast);
+                    self.compile_nil(ast)
                 } else {
                     match ls[0].sexpr {
-                        SExpr::Int(_) => {
-                            return self.error(&ls[0], "apply unexpect int");
-                        }
-
+                        SExpr::Int(_) => self.error(&ls[0], "apply unexpect int"),
                         SExpr::Atom(ref id) => {
                             match id.as_str() {
-                                "lambda" => {
-                                    return self.compile_lambda(ls);
-                                }
-
-                                "let" => {
-                                    return self.compile_let(ls);
-                                }
-
-                                "letrec" => {
-                                    return self.compile_letrec(ls);
-                                }
-
-                                "puts" => {
-                                    return self.compile_puts(ls);
-                                }
-
-                                "if" => {
-                                    return self.compile_if(ls);
-                                }
-
-                                "eq" => {
-                                    return self.compile_eq(ls);
-                                }
-
-                                "+" => {
-                                    return self.compile_add(ls);
-                                }
-
-                                "-" => {
-                                    return self.compile_sub(ls);
-                                }
-
-                                "cons" => {
-                                    return self.compile_cons(ls);
-                                }
-
-                                "car" => {
-                                    return self.compile_car(ls);
-                                }
-
-                                "cdr" => {
-                                    return self.compile_cdr(ls);
-                                }
-
-                                _ => {
-                                    return self.compile_apply(ls);
-                                }
+                                "lambda" => self.compile_lambda(ls),
+                                "let" => self.compile_let(ls),
+                                "letrec" => self.compile_letrec(ls),
+                                "puts" => self.compile_puts(ls),
+                                "if" => self.compile_if(ls),
+                                "eq" => self.compile_eq(ls),
+                                "+" => self.compile_add(ls),
+                                "-" => self.compile_sub(ls),
+                                "cons" => self.compile_cons(ls),
+                                "car" => self.compile_car(ls),
+                                "cdr" => self.compile_cdr(ls),
+                                _ => self.compile_apply(ls),
                             }
                         }
-
-                        SExpr::List(_) => {
-                            return self.compile_apply(&ls);
-                        }
+                        SExpr::List(_) => self.compile_apply(&ls),
                     }
                 }
             }
@@ -113,7 +66,7 @@ impl Compiler {
                       info: ast.info,
                       op: CodeOP::LDC(Rc::new(Lisp::Int(n))),
                   });
-        return Ok(());
+        Ok(())
     }
 
     fn compile_atom(&mut self, ast: &AST, id: &String) -> CompilerResult {
@@ -151,7 +104,7 @@ impl Compiler {
             }
         }
 
-        return Ok(());
+        Ok(())
     }
 
     fn compile_nil(&mut self, ast: &AST) -> CompilerResult {
@@ -160,7 +113,7 @@ impl Compiler {
                       info: ast.info,
                       op: CodeOP::LDC(Rc::new(Lisp::Nil)),
                   });
-        return Ok(());
+        Ok(())
     }
 
     fn compile_lambda(&mut self, ls: &Vec<AST>) -> CompilerResult {
@@ -208,7 +161,7 @@ impl Compiler {
                       op: CodeOP::LDF(args, body.code),
                   });
 
-        return Ok(());
+        Ok(())
     }
 
     fn compile_let(&mut self, ls: &Vec<AST>) -> CompilerResult {
@@ -232,7 +185,7 @@ impl Compiler {
 
         try!(self.compile_(&ls[3]));
 
-        return Ok(());
+        Ok(())
     }
 
     fn compile_letrec(&mut self, ls: &Vec<AST>) -> CompilerResult {
@@ -255,7 +208,7 @@ impl Compiler {
                   });
         try!(self.compile_(&ls[3]));
 
-        return Ok(());
+        Ok(())
     }
 
     fn compile_puts(&mut self, ls: &Vec<AST>) -> CompilerResult {
@@ -269,7 +222,7 @@ impl Compiler {
                       info: ls[0].info,
                       op: CodeOP::PUTS,
                   });
-        return Ok(());
+        Ok(())
     }
 
 
@@ -311,7 +264,7 @@ impl Compiler {
             }
         }
 
-        return Ok(());
+        Ok(())
     }
 
     fn compile_if(&mut self, ls: &Vec<AST>) -> CompilerResult {
@@ -346,7 +299,7 @@ impl Compiler {
                   });
 
 
-        return Ok(());
+        Ok(())
     }
 
 
@@ -363,7 +316,7 @@ impl Compiler {
                       op: CodeOP::EQ,
                   });
 
-        return Ok(());
+        Ok(())
     }
 
     fn compile_add(&mut self, ls: &Vec<AST>) -> CompilerResult {
@@ -379,7 +332,7 @@ impl Compiler {
                       op: CodeOP::ADD,
                   });
 
-        return Ok(());
+        Ok(())
     }
 
     fn compile_sub(&mut self, ls: &Vec<AST>) -> CompilerResult {
@@ -395,7 +348,7 @@ impl Compiler {
                       op: CodeOP::SUB,
                   });
 
-        return Ok(());
+        Ok(())
     }
 
     fn compile_cons(&mut self, ls: &Vec<AST>) -> CompilerResult {
@@ -411,7 +364,7 @@ impl Compiler {
                       op: CodeOP::CONS,
                   });
 
-        return Ok(());
+        Ok(())
     }
 
     fn compile_car(&mut self, ls: &Vec<AST>) -> CompilerResult {
@@ -426,7 +379,7 @@ impl Compiler {
                       op: CodeOP::CAR,
                   });
 
-        return Ok(());
+        Ok(())
     }
 
     fn compile_cdr(&mut self, ls: &Vec<AST>) -> CompilerResult {
@@ -441,6 +394,6 @@ impl Compiler {
                       op: CodeOP::CDR,
                   });
 
-        return Ok(());
+        Ok(())
     }
 }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -23,7 +23,7 @@ impl Compiler {
     }
 
     pub fn compile(&mut self, ast: &AST) -> Result<Code, Box<Error>> {
-        try!(self.compile_(ast));
+        self.compile_(ast)?;
         Ok(self.code.clone())
     }
 
@@ -148,7 +148,7 @@ impl Compiler {
 
         let mut body = Compiler::new();
         body.letrec_id_list = self.letrec_id_list.clone();
-        try!(body.compile_(&ls[2]));
+        body.compile_(&ls[2])?;
         body.code
             .push(CodeOPInfo {
                       info: ls[0].info,
@@ -176,14 +176,14 @@ impl Compiler {
 
         self.letrec_id_list.retain(|a| *a != id);
 
-        try!(self.compile_(&ls[2]));
+        self.compile_(&ls[2])?;
         self.code
             .push(CodeOPInfo {
                       info: ls[0].info,
                       op: CodeOP::LET(id),
                   });
 
-        try!(self.compile_(&ls[3]));
+        self.compile_(&ls[3])?;
 
         Ok(())
     }
@@ -200,13 +200,13 @@ impl Compiler {
 
         self.letrec_id_list.push(id.clone());
 
-        try!(self.compile_(&ls[2]));
+        self.compile_(&ls[2])?;
         self.code
             .push(CodeOPInfo {
                       info: ls[0].info,
                       op: CodeOP::LET(id),
                   });
-        try!(self.compile_(&ls[3]));
+        self.compile_(&ls[3])?;
 
         Ok(())
     }
@@ -216,7 +216,7 @@ impl Compiler {
             return self.error(&ls[0], "puts syntax");
         }
 
-        try!(self.compile_(&ls[1]));
+        self.compile_(&ls[1])?;
         self.code
             .push(CodeOPInfo {
                       info: ls[0].info,
@@ -229,14 +229,14 @@ impl Compiler {
     fn compile_apply(&mut self, ls: &Vec<AST>) -> CompilerResult {
         let (lambda, args) = ls.split_first().unwrap();
         for arg in args {
-            try!(self.compile_(arg));
+            self.compile_(arg)?;
         }
         self.code
             .push(CodeOPInfo {
                       info: ls[0].info,
                       op: CodeOP::ARGS(args.len()),
                   });
-        try!(self.compile_(lambda));
+        self.compile_(lambda)?;
 
         match lambda.sexpr {
             SExpr::Atom(ref id) => {
@@ -272,11 +272,11 @@ impl Compiler {
             return self.error(&ls[0], "if syntax");
         }
 
-        try!(self.compile_(&ls[1]));
+        self.compile_(&ls[1])?;
 
         let mut tc = Compiler::new();
         tc.letrec_id_list = self.letrec_id_list.clone();
-        try!(tc.compile_(&ls[2]));
+        tc.compile_(&ls[2])?;
         tc.code
             .push(CodeOPInfo {
                       info: ls[2].info,
@@ -285,7 +285,7 @@ impl Compiler {
 
         let mut fc = Compiler::new();
         fc.letrec_id_list = self.letrec_id_list.clone();
-        try!(fc.compile_(&ls[3]));
+        fc.compile_(&ls[3])?;
         fc.code
             .push(CodeOPInfo {
                       info: ls[3].info,
@@ -308,8 +308,8 @@ impl Compiler {
             return self.error(&ls[0], "eq syntax");
         }
 
-        try!(self.compile_(&ls[1]));
-        try!(self.compile_(&ls[2]));
+        self.compile_(&ls[1])?;
+        self.compile_(&ls[2])?;
         self.code
             .push(CodeOPInfo {
                       info: ls[0].info,
@@ -324,8 +324,8 @@ impl Compiler {
             return self.error(&ls[0], "add syntax");
         }
 
-        try!(self.compile_(&ls[1]));
-        try!(self.compile_(&ls[2]));
+        self.compile_(&ls[1])?;
+        self.compile_(&ls[2])?;
         self.code
             .push(CodeOPInfo {
                       info: ls[0].info,
@@ -340,8 +340,8 @@ impl Compiler {
             return self.error(&ls[0], "sub syntax");
         }
 
-        try!(self.compile_(&ls[1]));
-        try!(self.compile_(&ls[2]));
+        self.compile_(&ls[1])?;
+        self.compile_(&ls[2])?;
         self.code
             .push(CodeOPInfo {
                       info: ls[0].info,
@@ -356,8 +356,8 @@ impl Compiler {
             return self.error(&ls[0], "cons syntax");
         }
 
-        try!(self.compile_(&ls[1]));
-        try!(self.compile_(&ls[2]));
+        self.compile_(&ls[1])?;
+        self.compile_(&ls[2])?;
         self.code
             .push(CodeOPInfo {
                       info: ls[0].info,
@@ -372,7 +372,7 @@ impl Compiler {
             return self.error(&ls[0], "car syntax");
         }
 
-        try!(self.compile_(&ls[1]));
+        self.compile_(&ls[1])?;
         self.code
             .push(CodeOPInfo {
                       info: ls[0].info,
@@ -387,7 +387,7 @@ impl Compiler {
             return self.error(&ls[0], "cdr syntax");
         }
 
-        try!(self.compile_(&ls[1]));
+        self.compile_(&ls[1])?;
         self.code
             .push(CodeOPInfo {
                       info: ls[0].info,

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -32,7 +32,7 @@ impl Compiler {
             SExpr::Int(n) => self.compile_int(ast, n),
             SExpr::Atom(ref id) => self.compile_atom(ast, id),
             SExpr::List(ref ls) => {
-                if ls.len() == 0 {
+                if ls.is_empty() {
                     self.compile_nil(ast)
                 } else {
                     match ls[0].sexpr {

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -13,8 +13,8 @@ type CompilerResult = Result<(), Box<Error>>;
 impl Compiler {
     pub fn new() -> Self {
         Compiler {
-            code: vec![],
-            letrec_id_list: vec![],
+            code: Vec::new(),
+            letrec_id_list: Vec::new(),
         }
     }
 
@@ -121,7 +121,7 @@ impl Compiler {
             return self.error(&ls[0], "lambda syntax");
         }
 
-        let mut args: Vec<String> = vec![];
+        let mut args: Vec<String> = Vec::new();
         match ls[1].sexpr {
             SExpr::Atom(ref a) => {
                 args.push(a.clone());

--- a/src/data.rs
+++ b/src/data.rs
@@ -88,7 +88,7 @@ impl fmt::Display for AST {
                         write!(f, "{} ", list[i]).unwrap();
                     }
                 }
-                return write!(f, ")");
+                write!(f, ")")
             }
         }
     }
@@ -96,7 +96,7 @@ impl fmt::Display for AST {
 
 impl PartialEq for CodeOPInfo {
     fn eq(&self, a: &CodeOPInfo) -> bool {
-        return self.op == a.op;
+        self.op == a.op
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,12 +13,12 @@ use std::fs::File;
 use std::io::Read;
 
 pub fn run_lisp(s: &String) -> Result<Rc<Lisp>, Box<Error>> {
-    return SECD::new(try!(Compiler::new().compile(&try!(Parser::new(s).parse())))).run();
+    SECD::new(try!(Compiler::new().compile(&try!(Parser::new(s).parse())))).run()
 }
 
 pub fn run_lisp_file(s: &String) -> Result<Rc<Lisp>, Box<Error>> {
     let mut fh = try!(File::open(s));
     let mut src = String::new();
     try!(fh.read_to_string(&mut src));
-    return run_lisp(&src);
+    run_lisp(&src)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,12 +13,14 @@ use std::fs::File;
 use std::io::Read;
 
 pub fn run_lisp(s: &String) -> Result<Rc<Lisp>, Box<Error>> {
-    SECD::new(try!(Compiler::new().compile(&try!(Parser::new(s).parse())))).run()
+    let ast = &Parser::new(s).parse()?;
+    let code = Compiler::new().compile(ast)?;
+    SECD::new(code).run()
 }
 
 pub fn run_lisp_file(s: &String) -> Result<Rc<Lisp>, Box<Error>> {
-    let mut fh = try!(File::open(s));
+    let mut fh = File::open(s)?;
     let mut src = String::new();
-    try!(fh.read_to_string(&mut src));
+    fh.read_to_string(&mut src)?;
     run_lisp(&src)
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -164,7 +164,7 @@ impl Parser {
 
     pub fn parse(&mut self) -> ParserResult {
         let mut ps = 0;
-        let mut list: Vec<Vec<AST>> = vec![vec![]];
+        let mut list: Vec<Vec<AST>> = vec![Vec::new()];
 
         loop {
             match self.next()? {
@@ -191,7 +191,7 @@ impl Parser {
                         }
 
                         "(" => {
-                            list.push(vec![]);
+                            list.push(Vec::new());
                             ps += 1;
                         }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -26,11 +26,11 @@ fn is_id(c: char) -> bool {
 
 impl Parser {
     pub fn new(s: &String) -> Parser {
-        return Parser {
-                   src: s.clone(),
-                   pos: 0,
-                   info: [1; 2],
-               };
+        Parser {
+            src: s.clone(),
+            pos: 0,
+            info: [1; 2],
+        }
     }
 
     fn inc_line(&mut self) {
@@ -151,15 +151,15 @@ impl Parser {
             self.info = prev_info;
         }
 
-        return t;
+        t
     }
 
     pub fn next(&mut self) -> LexerResult {
-        return self.lex(false);
+        self.lex(false)
     }
 
     pub fn peek(&mut self) -> LexerResult {
-        return self.lex(true);
+        self.lex(true)
     }
 
     pub fn parse(&mut self) -> ParserResult {
@@ -217,9 +217,9 @@ impl Parser {
         }
 
         if ps > 0 {
-            return Err(From::from("many '('".to_string()));
+            Err(From::from("many '('".to_string()))
         } else {
-            return Ok(list.pop().unwrap().pop().unwrap());
+            Ok(list.pop().unwrap().pop().unwrap())
         }
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -167,7 +167,7 @@ impl Parser {
         let mut list: Vec<Vec<AST>> = vec![vec![]];
 
         loop {
-            match try!(self.next()) {
+            match self.next()? {
                 None => break,
 
                 Some(t) => {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -9,27 +9,27 @@ type VMResult = Result<(), Box<Error>>;
 
 impl SECD {
     pub fn new(c: Code) -> SECD {
-        return SECD {
-                   stack: vec![],
-                   env: HashMap::new(),
-                   code: c,
-                   dump: vec![],
-               };
+        SECD {
+            stack: vec![],
+            env: HashMap::new(),
+            code: c,
+            dump: vec![],
+        }
     }
 
     fn error(&self, i: Info, msg: &str) -> VMResult {
-        return Err(From::from(format!("{}:{}:vm error: {}", i[0], i[1], msg)));
+        Err(From::from(format!("{}:{}:vm error: {}", i[0], i[1], msg)))
     }
 
     pub fn run(&mut self) -> Result<Rc<Lisp>, Box<Error>> {
         try!(self.run_());
-        return Ok(self.stack.last().unwrap().clone());
+        Ok(self.stack.last().unwrap().clone())
     }
 
     fn run_(&mut self) -> VMResult {
         while self.code.len() > 0 {
             let c = self.code.remove(0);
-            match c.op { 
+            match c.op {
                 CodeOP::LET(id) => {
                     try!(self.run_let(c.info, id));
                 }
@@ -100,31 +100,31 @@ impl SECD {
             }
         }
 
-        return Ok(());
+        Ok(())
     }
 
 
     fn run_let(&mut self, _: Info, id: String) -> VMResult {
         let expr = self.stack.pop().unwrap();
         self.env.insert(id, expr);
-        return Ok(());
+        Ok(())
     }
 
     fn run_ld(&mut self, _: Info, id: String) -> VMResult {
         let expr = self.env.get(&id).unwrap();
         self.stack.push(expr.clone());
-        return Ok(());
+        Ok(())
     }
 
     fn run_ldc(&mut self, _: Info, lisp: Rc<Lisp>) -> VMResult {
         self.stack.push(lisp);
-        return Ok(());
+        Ok(())
     }
 
     fn run_ldf(&mut self, _: Info, names: Vec<String>, code: Code) -> VMResult {
         self.stack
             .push(Rc::new(Lisp::Closure(names, code, self.env.clone())));
-        return Ok(());
+        Ok(())
     }
 
     fn run_ap(&mut self, c: Info) -> VMResult {
@@ -145,8 +145,6 @@ impl SECD {
                         self.stack = vec![];
                         self.env = env;
                         self.code = code.clone();
-
-                        return Ok(());
                     }
                     _ => return self.error(c, "AP: expected List"),
                 }
@@ -154,6 +152,7 @@ impl SECD {
 
             _ => return self.error(c, "AP: expected Closure"),
         }
+        Ok(())
     }
 
     fn run_rap(&mut self, c: Info) -> VMResult {
@@ -174,8 +173,6 @@ impl SECD {
                         self.stack = vec![];
                         self.env.extend(env);
                         self.code = code.clone();
-
-                        return Ok(());
                     }
 
                     _ => return self.error(c, "RAP: expected List"),
@@ -184,6 +181,7 @@ impl SECD {
 
             _ => return self.error(c, "RAP: expected Closure"),
         }
+        Ok(())
     }
 
     fn run_ret(&mut self, c: Info) -> VMResult {
@@ -196,10 +194,10 @@ impl SECD {
 
                 self.stack.push(a.clone());
 
-                return Ok(());
+                Ok(())
             }
 
-            _ => return self.error(c, "RET: expected DumpAP"),
+            _ => self.error(c, "RET: expected DumpAP"),
         }
     }
 
@@ -210,12 +208,12 @@ impl SECD {
         }
 
         self.stack.push(Rc::new(Lisp::List(ls)));
-        return Ok(());
+        Ok(())
     }
 
     fn run_puts(&mut self, _: Info) -> VMResult {
         println!("{}", *self.stack.last().unwrap());
-        return Ok(());
+        Ok(())
     }
 
     fn run_sel(&mut self, c: Info, t: &Code, f: &Code) -> VMResult {
@@ -230,16 +228,16 @@ impl SECD {
 
         self.code = code.clone();
 
-        return Ok(());
+        Ok(())
     }
 
     fn run_join(&mut self, c: Info) -> VMResult {
         if let DumpOP::DumpSEL(ref code) = self.dump.pop().unwrap() {
             self.code = code.clone();
 
-            return Ok(());
+            Ok(())
         } else {
-            return self.error(c, "JOIN: expected DumpSEL");
+            self.error(c, "JOIN: expected DumpSEL")
         }
     }
 
@@ -249,7 +247,7 @@ impl SECD {
         self.stack
             .push(Rc::new(if a == b { Lisp::True } else { Lisp::False }));
 
-        return Ok(());
+        Ok(())
     }
 
     fn run_add(&mut self, c: Info) -> VMResult {
@@ -259,12 +257,12 @@ impl SECD {
             if let Lisp::Int(m) = *b {
                 self.stack.push(Rc::new(Lisp::Int(m + n)));
 
-                return Ok(());
+                Ok(())
             } else {
-                return self.error(c, "ADD: expected int");
+                self.error(c, "ADD: expected int")
             }
         } else {
-            return self.error(c, "ADD: expected int");
+            self.error(c, "ADD: expected int")
         }
     }
 
@@ -275,12 +273,12 @@ impl SECD {
             if let Lisp::Int(o) = *b {
                 self.stack.push(Rc::new(Lisp::Int(o - n)));
 
-                return Ok(());
+                Ok(())
             } else {
-                return self.error(c, "SUB: expected int");
+                self.error(c, "SUB: expected int")
             }
         } else {
-            return self.error(c, "SUB: expected int");
+            self.error(c, "SUB: expected int")
         }
     }
 
@@ -289,7 +287,7 @@ impl SECD {
         let b = self.stack.pop().unwrap();
         self.stack.push(Rc::new(Lisp::Cons(b, a)));
 
-        return Ok(());
+        Ok(())
     }
 
     fn run_car(&mut self, c: Info) -> VMResult {
@@ -297,9 +295,9 @@ impl SECD {
         if let Lisp::Cons(ref car, _) = *a {
             self.stack.push(car.clone());
 
-            return Ok(());
+            Ok(())
         } else {
-            return self.error(c, "CAR: expected Cons");
+            self.error(c, "CAR: expected Cons")
         }
     }
 
@@ -308,9 +306,9 @@ impl SECD {
         if let Lisp::Cons(_, ref cdr) = *a {
             self.stack.push(cdr.clone());
 
-            return Ok(());
+            Ok(())
         } else {
-            return self.error(c, "CDR: expected Cons");
+            self.error(c, "CDR: expected Cons")
         }
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -127,7 +127,7 @@ impl SECD {
         return Ok(());
     }
 
-    fn run_ap(mut self, c: Info) -> VMResult {
+    fn run_ap(&mut self, c: Info) -> VMResult {
         match *self.stack.pop().unwrap() {
             Lisp::Closure(ref names, ref code, ref env) => {
                 match *self.stack.pop().unwrap() {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -10,10 +10,10 @@ type VMResult = Result<(), Box<Error>>;
 impl SECD {
     pub fn new(c: Code) -> SECD {
         SECD {
-            stack: vec![],
+            stack: Vec::new(),
             env: HashMap::new(),
             code: c,
-            dump: vec![],
+            dump: Vec::new(),
         }
     }
 
@@ -142,7 +142,7 @@ impl SECD {
                                                  self.env.clone(),
                                                  self.code.clone()));
 
-                        self.stack = vec![];
+                        self.stack = Vec::new();
                         self.env = env;
                         self.code = code.clone();
                     }
@@ -170,7 +170,7 @@ impl SECD {
                                                  self.env.clone(),
                                                  self.code.clone()));
 
-                        self.stack = vec![];
+                        self.stack = Vec::new();
                         self.env.extend(env);
                         self.code = code.clone();
                     }
@@ -202,7 +202,7 @@ impl SECD {
     }
 
     fn run_args(&mut self, _: Info, n: usize) -> VMResult {
-        let mut ls = vec![];
+        let mut ls = Vec::new();
         for _ in 0..n {
             ls.insert(0, self.stack.pop().unwrap());
         }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -22,7 +22,7 @@ impl SECD {
     }
 
     pub fn run(&mut self) -> Result<Rc<Lisp>, Box<Error>> {
-        try!(self.run_());
+        self.run_()?;
         Ok(self.stack.last().unwrap().clone())
     }
 
@@ -31,71 +31,71 @@ impl SECD {
             let c = self.code.remove(0);
             match c.op {
                 CodeOP::LET(id) => {
-                    try!(self.run_let(c.info, id));
+                    self.run_let(c.info, id)?;
                 }
 
                 CodeOP::LD(id) => {
-                    try!(self.run_ld(c.info, id));
+                    self.run_ld(c.info, id)?;
                 }
 
                 CodeOP::LDC(lisp) => {
-                    try!(self.run_ldc(c.info, lisp));
+                    self.run_ldc(c.info, lisp)?;
                 }
 
                 CodeOP::LDF(names, code) => {
-                    try!(self.run_ldf(c.info, names, code));
+                    self.run_ldf(c.info, names, code)?;
                 }
 
                 CodeOP::RET => {
-                    try!(self.run_ret(c.info));
+                    self.run_ret(c.info)?;
                 }
 
                 CodeOP::AP => {
-                    try!(self.run_ap(c.info));
+                    self.run_ap(c.info)?;
                 }
 
                 CodeOP::RAP => {
-                    try!(self.run_rap(c.info));
+                    self.run_rap(c.info)?;
                 }
 
                 CodeOP::ARGS(n) => {
-                    try!(self.run_args(c.info, n));
+                    self.run_args(c.info, n)?;
                 }
 
                 CodeOP::PUTS => {
-                    try!(self.run_puts(c.info));
+                    self.run_puts(c.info)?;
                 }
 
                 CodeOP::SEL(ref t, ref f) => {
-                    try!(self.run_sel(c.info, t, f));
+                    self.run_sel(c.info, t, f)?;
                 }
 
                 CodeOP::JOIN => {
-                    try!(self.run_join(c.info));
+                    self.run_join(c.info)?;
                 }
 
                 CodeOP::EQ => {
-                    try!(self.run_eq(c.info));
+                    self.run_eq(c.info)?;
                 }
 
                 CodeOP::ADD => {
-                    try!(self.run_add(c.info));
+                    self.run_add(c.info)?;
                 }
 
                 CodeOP::SUB => {
-                    try!(self.run_sub(c.info));
+                    self.run_sub(c.info)?;
                 }
 
                 CodeOP::CONS => {
-                    try!(self.run_cons(c.info));
+                    self.run_cons(c.info)?;
                 }
 
                 CodeOP::CAR => {
-                    try!(self.run_car(c.info));
+                    self.run_car(c.info)?;
                 }
 
                 CodeOP::CDR => {
-                    try!(self.run_cdr(c.info));
+                    self.run_cdr(c.info)?;
                 }
             }
         }


### PR DESCRIPTION
Qiita の記事に [コメントしました通り](http://qiita.com/kmtoki/items/cc5bb1204fcba166fd6f#comment-56bb2915e745944617a4)、無駄な clone などを省くことによってSECDマシンが高速化できました。

この後、2つの PR を送りますが、それに先立って、コードのクリーンアップをしました。

- コンパイルエラーの修正（cannot move out of borrowed content）
- rustfmt によるコード整形
- 不要な `return` キーワードの削除
- `try!` マクロを `?` 演算子に変更
- `vec![]` を `Vec::new()` に変更。マクロを展開したレベルでは、前者は空のベクタを作りには少し効率が悪そうなコードになります。（LLVM によって最終的に同じレベルまで最適化されるのかもしれないので実質は違いがないかもしれませんが。）
- `if ... len() == 0` を `if ... is_empty()` に変更。

よろしくお願いします